### PR TITLE
feat: GitHub Pages自動デプロイ機能を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Build for GitHub Pages
+        run: npm run build:github
+        
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "build:github": "tsc && vite build --mode production",
     "preview": "vite preview",
     "scrape": "node --loader ts-node/esm scraping/pick-hotel-cheapest-price.ts"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [react()],
-  assetsInclude: ['**/*.tsv']
-})
+  assetsInclude: ['**/*.tsv'],
+  base: command === 'build' ? '/min_price_list/' : '/'
+}))


### PR DESCRIPTION
## Summary
- vite.config.tsに環境別ベースパス設定を追加（開発時'/'、GitHub Pages'/min_price_list/'）
- package.jsonにGitHub Pages専用ビルドスクリプト（build:github）を追加
- GitHub Actionsワークフローファイルを作成し、mainブランチプッシュ時の自動デプロイを設定

## Test plan
- [x] ローカル開発環境での動作確認（npm run dev → http://localhost:5173/）
- [x] GitHub Pages用ビルドテスト（npm run build:github）
- [x] ローカルプレビューでのパス確認（http://localhost:4173/min_price_list/）
- [ ] GitHub Pages設定を"GitHub Actions"に変更済み
- [ ] PRマージ後の自動デプロイ確認

🤖 Generated with [Claude Code](https://claude.ai/code)